### PR TITLE
Initial claim definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# test-network-function-claim
+
+`test-network-function-claim` provides a JSON Schema definition for a
+[test-network-function](https://github.com/redhat-nfvpe/test-network-function) claim based on
+[JSON Schema Draft-07](https://json-schema.org/draft-07/json-schema-release-notes.html).
+
+A claim contains:
+* A start time for the claim evaluation.
+* A description of the Hardware System(s) Under Test
+* All test configurations used by tests.
+* All tests run, and their respective results.
+* An end time for the claim evaluation.

--- a/claim-schema.json
+++ b/claim-schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "version": "0.0.1",
+  "description": "Represents a test-network-function claim.",
+  "additionalProperties": false,
+  "properties": {
+    "claim": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "startTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The claim evaluation start time."
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The claim evaluation end time."
+        },
+        "tnfVersion": {
+          "type": "string",
+          "description": "The test-network-function (tnf) commit hash."
+        },
+        "testConfigurations": {
+          "type": "object",
+          "description": "The key/value configuration data to perform the given claim tests."
+        },
+        "hosts": {
+          "type": "object",
+          "description": "Hostname/payload key/value information for all hosts in the cluster.",
+          "properties": {
+            "lshwOutput": {
+              "type": "object",
+              "description": "A description of a host using the Unix lshw command."
+            }
+          }
+        },
+        "junitResults": {
+          "type": "object",
+          "description": "JUnit test results."
+        }
+      },
+      "required": [
+        "startTime",
+        "endTime",
+        "tnfVersion",
+        "testConfigurations",
+        "hosts",
+        "junitResults"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This is an initial JSON Schema representation of a codified claim.
Some significant concerns surround the following:
* Ginkgo has no way of reporting test results as JSON.  Thus, a new
  Reporter implementation may need to be created to stream results
  as JSON.
* Configuration in `test-network-function` is currently the wild
  west.  Part of this is due to the fact that Ginkgo test suites are
  not structs, and thus it is incredibly difficult to enforce any
  interface for a test suite.  Thus, we have a few options:
  1) Find a way to wrap Ginkgo in a struct.  This is atypical, and
     probably not recommended.
  2) Create a Singleton which has a collection of all test configs.
     This is decent, flexible, and adheres to GoLang's lack of
     strong interface requirements.  However, this will require
     self registration which is fraught with human error.
  3) Abstract a meta parent interface.  This is also limited, since
     GoLang is strongly typed.
  There are options; it just needs to be thought out a bit more.

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>