### PR TITLE
Update GolangCI-lint to v1.60.1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -123,6 +123,6 @@ issues:
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.59.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.60.x # use the fixed version to not introduce new linters unexpectedly
   prepare:
     - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ At a minimum, the following dependencies must be installed to work with the GoLa
 Dependency|Minimum Version
 ---|---
 [GoLang](https://golang.org/dl/)|1.22
-[golangci-lint](https://golangci-lint.run/usage/install/)|1.59
+[golangci-lint](https://golangci-lint.run/usage/install/)|1.60
 
 ## Modifying the claim schema
 


### PR DESCRIPTION
Related to: https://github.com/redhat-best-practices-for-k8s/certsuite/pull/2362