### PR TITLE
docs: fix Go version in CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,7 @@ From `go.mod`:
 ## Development Guidelines
 
 ### Go Version
-This repository uses Go 1.26.1.
+This repository uses Go 1.26.
 
 ### Modifying the Claim Schema
 


### PR DESCRIPTION
## Summary
- Fix Go version in CLAUDE.md from 1.26.1 to 1.26 to match go.mod

## Test plan
- [ ] Verify CLAUDE.md Go version matches go.mod